### PR TITLE
fix(virt): only append nested virtualization flag if not already present

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -20,5 +20,6 @@
 #    - nvidia
 #    - containers
 #    - browsers
-    - applications
-    - gnome
+#    - applications
+#    - gnome
+    - virtualization

--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -42,7 +42,7 @@
   shell: |
     modprobe -r kvm_intel
     modprobe kvm_intel nested=1
-    echo "options kvm_intel nested=1" >> /etc/modprobe.d/kvm.conf
+    if ! grep -q "kvm_intel" /etc/modprobe.d/kvm.conf; then echo "options kvm_intel nested=1" >> /etc/modprobe.d/kvm.conf; fi
 
 - name: Check if nested virtualization is enabled
   become: true


### PR DESCRIPTION
enable nested virtualization permanently only If `options kvm_intel nested=1` doesn't already exist in `/etc/modprobe.d/kvm.conf`